### PR TITLE
fix: cut useless suffix of tmux version

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,5 @@
 # Environment
-run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -c 6-)"
+run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -c 6-8)"
 set -g xterm-keys on
 set -sg escape-time 0	 # fix vim esc delay: https://github.com/neovim/neovim/wiki/FAQ#esc-in-tmux-or-gnu-screen-is-delayed
 set-option -g set-titles on


### PR DESCRIPTION
Some tmux have version suffix `a`, here is an example output of my zsh terminal
```
>>> tmux -V
tmux 3.3a
```
You may also check the release version from [tmux release note](https://github.com/tmux/tmux/releases).
It would make code [here](https://github.com/ppwwyyxx/dotfiles/blob/e37f57f13c3516a05479dba2cae2f6e2c8270db5/.tmux.conf#L19-L20) failed and tools like imgcat won't work on some machines.

PTAL @ppwwyyxx 